### PR TITLE
escape_quote_argument: fix about backslash and number string.

### DIFF
--- a/exe/git-cococo
+++ b/exe/git-cococo
@@ -20,7 +20,7 @@ uncommitted_changes_are_exists() {
 escape_quote_argument() {
   # In MacOSX, sed adds "\n" to tail of stream.
   # echo_n rejects tail "\n".
-  echo_n "$(echo "$1" | sed -e s/\'/\'\\\\\'\'/g)"
+  echo_n "$(echo_n "$1" | sed -e s/\'/\'\\\\\'\'/g)"
 }
 
 escape_one_argument() {

--- a/test/unit/escaping_test.rb
+++ b/test/unit/escaping_test.rb
@@ -12,6 +12,7 @@ class EscapingTest < UnitTestCase
     data(without_quote_charactor: %w[foo foo],
          with_space_charactor: ["abc def", "abc def"],
          with_linefeed_charactor: ["abc\ndef", "abc\ndef"],
+         with_backslash_charactor: %w[abc\1def abc\1def],
          with_quote_charactor: %w[abc'def abc'\''def])
     test_escaping
   end


### PR DESCRIPTION
# Before

```
$ . ./exe/git-cococo
$ escape_quote_argument '\1' | hd
00000000  01                                                |.|
00000001
```

# After

```
$ . ./exe/git-cococo
$ escape_quote_argument '\1' | hd                     
00000000  5c 31                                             |\1|
00000002
```
