### PR TITLE
add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@
 
 ## Installation
 
-`git cococo` is written by shell script. So we can install following:
+### Using install script
+
+`git cococo` can be installed using the following command:
+
+```console
+$ curl -fsL https://raw.githubusercontent.com/nishidayuya/git-cococo/main/install.sh | sh
+```
+
+For system-wide installation, run with `sudo`:
+
+```console
+$ curl -fsL https://raw.githubusercontent.com/nishidayuya/git-cococo/main/install.sh | sudo sh
+```
+
+### Manual installation
+
+`git cococo` is written in shell script, so we can also install it manually:
 
 ```console
 $ wget https://raw.githubusercontent.com/nishidayuya/git-cococo/master/exe/git-cococo

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+# Determine installation directory
+if [ "$(id -u)" -eq 0 ]; then
+  BIN_DIR="/usr/local/bin"
+else
+  BIN_DIR="$HOME/.local/bin"
+fi
+
+# Create directory if it doesn't exist
+mkdir -p "$BIN_DIR"
+
+# Download git-cococo
+URL="https://raw.githubusercontent.com/nishidayuya/git-cococo/main/exe/git-cococo"
+TARGET="$BIN_DIR/git-cococo"
+
+echo "Installing git-cococo to $TARGET..."
+
+if command -v curl >/dev/null 2>&1; then
+  curl -fsL "$URL" -o "$TARGET"
+elif command -v wget >/dev/null 2>&1; then
+  wget -q "$URL" -O "$TARGET"
+else
+  echo "Error: curl or wget is required to install git-cococo." >&2
+  exit 1
+fi
+
+# Set executable permission
+chmod +x "$TARGET"
+
+echo "Successfully installed git-cococo to $TARGET"
+
+# Check if BIN_DIR is in PATH
+if [ "$BIN_DIR" = "$HOME/.local/bin" ]; then
+  case ":$PATH:" in
+    *:"$BIN_DIR":*) ;;
+    *)
+      echo ""
+      echo "Warning: $BIN_DIR is not in your PATH."
+      echo "You may need to add it to your shell's configuration file (e.g., ~/.bashrc or ~/.zshrc):"
+      echo "  export PATH=\"\$PATH:$BIN_DIR\""
+      ;;
+  esac
+fi

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,8 @@ fi
 mkdir -p "$BIN_DIR"
 
 # Download git-cococo
-URL="https://raw.githubusercontent.com/nishidayuya/git-cococo/main/exe/git-cococo"
+REF="${GIT_COCOCO_REF:-main}"
+URL="https://raw.githubusercontent.com/nishidayuya/git-cococo/$REF/exe/git-cococo"
 TARGET="$BIN_DIR/git-cococo"
 
 echo "Installing git-cococo to $TARGET..."


### PR DESCRIPTION
This pull request adds an installation script (`install.sh`) to simplify the installation process and updates the `README.md` accordingly.

### Changes:

- **Added `install.sh`**:
  - Automatically detects the installation directory:
    - `/usr/local/bin/` when run with `sudo` (root).
    - `~/.local/bin/` when run as a regular user.
  - Supports `GIT_COCOCO_REF` environment variable to install a specific version/commit.
  - Uses `curl` or `wget` for downloading the script.
  - Sets executable permissions on the installed file.
  - Provides a hint to update `PATH` if the installation directory is not in the environment variable.
- **Updated `README.md`**:
  - Added instructions for using the installation script at the beginning of the "Installation" section.
  - Moved existing command-line instructions to a "Manual installation" subsection.
  - Adjusted the language to use "we" for consistency with the project's style.

### Verification:

Verified the script's behavior using a `debian:13` Docker image for both root and regular user scenarios:
- **Root installation**:
  `docker run --rm -v "$(pwd):/work" debian:13 sh -c "apt-get update -qq && apt-get install -y -qq curl ca-certificates > /dev/null && /work/install.sh"`
- **Regular user installation**:
  `docker run --rm -v "$(pwd):/work" debian:13 sh -c "apt-get update -qq && apt-get install -y -qq curl ca-certificates > /dev/null && useradd -m tester && su - tester -c \"/work/install.sh\""`
